### PR TITLE
Fix option 2

### DIFF
--- a/script.js
+++ b/script.js
@@ -36,8 +36,6 @@ function generateQuote() {
     });
   tweetBtn.addEventListener("click", shareTweet);
 
-  shareTweet();
-
   function shareTweet(event) {
     const twitterUrl =
       "https://twitter.com/intent/tweet?text=${quoteText} -${quoteAuthor}";

--- a/script.js
+++ b/script.js
@@ -37,8 +37,11 @@ function generateQuote() {
   tweetBtn.addEventListener("click", shareTweet);
 
   function shareTweet(event) {
+    var quoteText = quote.innerText;
+    var quoteAuthor = author.innerText;
+
     const twitterUrl =
-      "https://twitter.com/intent/tweet?text=${quoteText} -${quoteAuthor}";
+      `https://twitter.com/intent/tweet?text=${quoteText} -${quoteAuthor}`;
     window.open(twitterUrl, "_blank");
   }
 }


### PR DESCRIPTION
- Removes `shareTweet()` call without click, as it triggers a popup which is blocked by browser popup-blockers anyway (eg. likely wont do anything)
- Changed from double quotes (`"`) to backtick as that is required for using the `${var}` syntax in JS.
- Retrieve `quoteText` and `quoteAuthor` from the respective element's `innerText`.