### PR TITLE
Stopped calling shareTweet before needed and fixed scope issue

### DIFF
--- a/script.js
+++ b/script.js
@@ -10,6 +10,9 @@ quoteBtn.addEventListener("click", generateQuote);
 generateQuote();
 
 function generateQuote() {
+  var quoteText = "";
+  var quoteAuthor = "";
+
   const config = {
     headers: {
       Accept: "application/json",
@@ -22,8 +25,8 @@ function generateQuote() {
     .then(function (data) {
       var number = Math.floor(Math.random() * data.length);
       console.log(data[number]);
-      var quoteText = data[number].text;
-      var quoteAuthor = data[number].author;
+      quoteText = data[number].text;
+      quoteAuthor = data[number].author;
       quote.innerHTML = quoteText;
       if (quoteAuthor === null) {
         author.innerHTML = "- " + "Anonymous" + " -";
@@ -36,11 +39,9 @@ function generateQuote() {
     });
   tweetBtn.addEventListener("click", shareTweet);
 
-  shareTweet();
-
   function shareTweet(event) {
     const twitterUrl =
-      "https://twitter.com/intent/tweet?text=${quoteText} -${quoteAuthor}";
+      `https://twitter.com/intent/tweet?text=${quoteText} -${quoteAuthor}`;
     window.open(twitterUrl, "_blank");
   }
 }


### PR DESCRIPTION
- Removes `shareTweet()` call without click, as it triggers a popup which is blocked by browser popup-blockers anyway (eg. likely wont do anything)
- Changed from double quotes (`"`) to backtick as that is required for using the `${var}` syntax in JS.
- Moved the `quoteText` and `quoteAuthor` variables out of the method call (`then(....)`) and out in the main function, so that it is scoped properly for `shareTweet() ` to be able to read them.